### PR TITLE
Remove Apache dependencies

### DIFF
--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -210,11 +210,7 @@ appengine_war = rule(
             default = Label("//external:appengine/java/jars"),
         ),
         "_appengine_deps": attr.label_list(
-            default = [
-                Label("@com_google_appengine_java//:api"),
-                Label("@org_apache_commons_lang//jar"),
-                Label("@org_apache_commons_collections//jar"),
-            ],
+            default = [Label("@com_google_appengine_java//:api")],
         ),
         "jars": attr.label_list(
             allow_files = jar_filetype,
@@ -291,14 +287,4 @@ def appengine_repositories():
   native.bind(
       name = "javax/servlet/api",
       actual = "@bazel_tools//appengine:javax.servlet.api",
-  )
-
-  native.maven_jar(
-      name = "org_apache_commons_lang",
-      artifact = "commons-lang:commons-lang:2.6",
-  )
-
-  native.maven_jar(
-      name = "org_apache_commons_collections",
-      artifact = "commons-collections:commons-collections:3.2.2",
   )


### PR DESCRIPTION
These aren't actually used. I think these used to be runtime dependencies
of dash, which made me think they were required for AppEngine rules, but
they are not.