### PR TITLE
Fix runfiles path in check_war test

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -15,5 +15,9 @@ filegroup(
 sh_test(
     name = "check_war",
     srcs = ["check_war.sh"],
-    data = [":test-war"],
+    data = [
+        ":test-war",
+        "@local_jdk//:jar",
+        "@local_jdk//:jdk-default",
+    ],
 )

--- a/test/check_war.sh
+++ b/test/check_war.sh
@@ -2,13 +2,18 @@
 
 set -e
 
-TEST_WAR="$TEST_SRCDIR/test/test-war.war"
+RUNFILES="$TEST_SRCDIR"
+if [ -d "${TEST_SRCDIR}/io_bazel_rules_appengine" ]; then
+  RUNFILES="${TEST_SRCDIR}/io_bazel_rules_appengine"
+fi
+TEST_WAR="${RUNFILES}/test/test-war.war"
+JAR="${RUNFILES}/external/local_jdk/bin/jar"
 
 function assert_war_contains() {
   local needle="$1"
-  jar -tf "$TEST_WAR" | grep -sq "$needle" && return 0
+  "${JAR}" -tf "$TEST_WAR" | grep -sq "$needle" && return 0
   echo "Contents of $TEST_WAR:"
-  jar -tf "$TEST_WAR"
+  "${JAR}" -tf "$TEST_WAR"
   echo "Expected '$needle' in $TEST_WAR"
   return 1
 }


### PR DESCRIPTION
Also use jar from local_jdk instead of relying on it on the PATH

Fix build with bazel @HEAD