### PR TITLE
Add workspace name to runfiles path

### DIFF
--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -161,11 +161,12 @@ def _war_impl(ctxt):
       for jar in ctxt.files._appengine_jars
       ]
   substitutions = {
-    "%{zipper}": ctxt.file._zipper.short_path,
-    "%{war}": ctxt.outputs.war.short_path,
-    "%{java}": ctxt.file._java.short_path,
-    "%{appengine_sdk}": appengine_sdk,
-    "%{classpath}":  (":".join(classpath)),
+      "%{workspace_name}" : ctxt.workspace_name,
+      "%{zipper}": ctxt.file._zipper.short_path,
+      "%{war}": ctxt.outputs.war.short_path,
+      "%{java}": ctxt.file._java.short_path,
+      "%{appengine_sdk}": appengine_sdk,
+      "%{classpath}":  (":".join(classpath)),
   }
   ctxt.template_action(
       output = executable,

--- a/appengine/appengine_runner.sh.template
+++ b/appengine/appengine_runner.sh.template
@@ -19,8 +19,8 @@ case "$0" in
 esac
 
 if [[ -z "$JAVA_RUNFILES" ]]; then
-  if [[ -e "${self}.runfiles" ]]; then
-    JAVA_RUNFILES="${self}.runfiles"
+  if [[ -e "${self}.runfiles/%{workspace_name}" ]]; then
+    JAVA_RUNFILES="${self}.runfiles/%{workspace_name}"
   fi
 fi
 


### PR DESCRIPTION
This fixes the appengine rules to work when the workspace name is set.

This finishes fixing https://github.com/bazelbuild/bazel/issues/1233.

CC @pmbethe09.