### PR TITLE
Run dev app server directly from runfiles tree

### DIFF
--- a/appengine/appengine_runner.sh.template
+++ b/appengine/appengine_runner.sh.template
@@ -24,13 +24,6 @@ if [[ -z "$JAVA_RUNFILES" ]]; then
   fi
 fi
 
-root_path=$(pwd)
-tmp_dir=$(mktemp -d ${TMPDIR:-/tmp}/war.XXXXXXXX)
-trap "{ cd ${root_path}; rm -rf ${tmp_dir}; }" EXIT
-cd ${tmp_dir}
-
-${JAVA_RUNFILES}/%{zipper} x ${JAVA_RUNFILES}/%{war}
-
 jvm_bin=${JAVA_RUNFILES}/%{java}
 if [[ ! -x ${jvm_bin} ]]; then
   jvm_bin=$(which java)
@@ -40,13 +33,20 @@ APP_ENGINE_ROOT=${JAVA_RUNFILES}/%{appengine_sdk}
 main_class="com.google.appengine.tools.development.DevAppServerMain"
 classpath="%{classpath}"
 
+# If we are not on the data path, we'll get a warning:
+# WARNING: Your working directory, ($PWD) is not equal to your
+# web application root (%{data_path})
+# You will not be able to access files from your working directory on the
+# production server.
+cd "%{data_path}"
+
+mkdir -p WEB-INF/lib
+for i in $(echo $classpath | tr ":" "\n")
+do
+    jar="WEB-INF/lib/$(basename $i)"
+    rm -f "$jar"
+    ln -s "$i" "$jar"
+done
+
 ${jvm_bin} -Dappengine.sdk.root=${APP_ENGINE_ROOT} -cp "${classpath}" \
-    ${main_class} "$@" ${tmp_dir}
-retCode=$?
-
-# We remove the trap so the return code doesn't get intercepted by it on OS X.
-cd ${root_path}
-rm -rf ${tmp_dir}
-trap - EXIT
-
-exit $retCode
+    ${main_class} "." "$@"


### PR DESCRIPTION
Previously, these rules were zipping up a .war and then, when the
executable ran, it would make a temporary directory and unzip the war
there. It is faster to develop just using the runfiles tree.

This commit also makes several other changes (that I can split out if
you prefer):

* Doesn’t include every jar in the app engine sdk in the build (only
the ones that, AFAICT, you actually need).
* Fails fast if the app engine sdk glob didn’t return anything (which
happens to me a lot when I use a local_repo for
com_google_appengine_java because I always forget it expects an
APPENGINE_DIR subdirectory).
* Uses .format for python string replacement