### PR TITLE
Un-revert "Run dev app server directly from runfiles tree (#24)"

### DIFF
--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -155,7 +155,8 @@ def _war_impl(ctxt):
     elif not f.path.startswith(appengine_sdk):
       appengine_sdk = _common_substring(appengine_sdk, f.short_path)
   if not appengine_sdk:
-    fail("Could not find appengine files")
+    fail("could not find appengine files",
+         attr = str(ctxt.attr._appengine_sdk.label))
 
   classpath = ["${JAVA_RUNFILES}/%s" % jar.short_path for jar in transitive_deps]
   classpath += [

--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -154,11 +154,15 @@ def _war_impl(ctxt):
       appengine_sdk = f.short_path
     elif not f.path.startswith(appengine_sdk):
       appengine_sdk = _common_substring(appengine_sdk, f.short_path)
+  if not appengine_sdk:
+    fail("Could not find appengine files")
 
-  classpath = [
+  classpath = ["${JAVA_RUNFILES}/%s" % jar.short_path for jar in transitive_deps]
+  classpath += [
       "${JAVA_RUNFILES}/%s" % jar.short_path
-      for jar in ctxt.files._appengine_jars
-      ]
+      for jar in ctxt.files._appengine_deps
+  ]
+
   substitutions = {
       "%{workspace_name}" : ctxt.workspace_name,
       "%{zipper}": ctxt.file._zipper.short_path,
@@ -166,7 +170,9 @@ def _war_impl(ctxt):
       "%{java}": ctxt.file._java.short_path,
       "%{appengine_sdk}": appengine_sdk,
       "%{classpath}":  (":".join(classpath)),
+      "%{data_path}": data_path
   }
+
   ctxt.template_action(
       output = executable,
       template = ctxt.file._runner_template,
@@ -179,8 +185,9 @@ def _war_impl(ctxt):
       executable = True)
 
   runfiles = ctxt.runfiles(files = [war, executable]
+                           + list(transitive_deps)
+                           + inputs
                            + ctxt.files._appengine_sdk
-                           + ctxt.files._appengine_jars
                            + [ctxt.file._java, ctxt.file._zipper])
   return struct(runfiles = runfiles)
 
@@ -205,9 +212,6 @@ appengine_war = rule(
         ),
         "_appengine_sdk": attr.label(
             default = Label("@com_google_appengine_java//:sdk"),
-        ),
-        "_appengine_jars": attr.label(
-            default = Label("@com_google_appengine_java//:jars"),
         ),
         "_appengine_deps": attr.label_list(
             default = [Label("@com_google_appengine_java//:api")],
@@ -241,24 +245,28 @@ APPENGINE_BUILD_FILE = """
 # BUILD file to use the Java AppEngine SDK with a remote repository.
 java_import(
     name = "jars",
-    jars = glob(["%s/lib/**/*.jar"]),
+    jars = glob(["{appengine}/lib/**/*.jar"]),
     visibility = ["//visibility:public"],
 )
 
 java_import(
     name = "api",
-    jars = ["%s/lib/impl/appengine-api.jar"],
+    jars = [
+        "{appengine}/lib/agent/appengine-agent.jar",
+        "{appengine}/lib/appengine-tools-api.jar",
+        "{appengine}/lib/impl/appengine-api.jar",
+    ],
     visibility = ["//visibility:public"],
     neverlink = 1,
 )
 
 filegroup(
     name = "sdk",
-    srcs = glob(["%s/**"]),
+    srcs = glob(["{appengine}/**"]),
     visibility = ["//visibility:public"],
-    path = "%s",
+    path = "{appengine}",
 )
-""" % (APPENGINE_DIR, APPENGINE_DIR, APPENGINE_DIR, APPENGINE_DIR)
+""".format(appengine = APPENGINE_DIR)
 
 def _find_locally_or_download_impl(repository_ctx):
   if 'APPENGINE_SDK_PATH' in repository_ctx.os.environ:

--- a/appengine/appengine_runner.sh.template
+++ b/appengine/appengine_runner.sh.template
@@ -24,13 +24,6 @@ if [[ -z "$JAVA_RUNFILES" ]]; then
   fi
 fi
 
-root_path=$(pwd)
-tmp_dir=$(mktemp -d ${TMPDIR:-/tmp}/war.XXXXXXXX)
-trap "{ cd ${root_path}; rm -rf ${tmp_dir}; }" EXIT
-cd ${tmp_dir}
-
-${JAVA_RUNFILES}/%{zipper} x ${JAVA_RUNFILES}/%{war}
-
 jvm_bin=${JAVA_RUNFILES}/%{java}
 if [[ ! -x ${jvm_bin} ]]; then
   jvm_bin=$(which java)
@@ -40,13 +33,20 @@ APP_ENGINE_ROOT=${JAVA_RUNFILES}/%{appengine_sdk}
 main_class="com.google.appengine.tools.development.DevAppServerMain"
 classpath="%{classpath}"
 
+# If we are not on the data path, we'll get a warning:
+# WARNING: Your working directory, ($PWD) is not equal to your
+# web application root (%{data_path})
+# You will not be able to access files from your working directory on the
+# production server.
+cd "%{data_path}"
+
+mkdir -p WEB-INF/lib
+for i in $(echo $classpath | tr ":" "\n")
+do
+    jar="WEB-INF/lib/$(basename $i)"
+    rm -f "$jar"
+    ln -s "$i" "$jar"
+done
+
 ${jvm_bin} -Dappengine.sdk.root=${APP_ENGINE_ROOT} -cp "${classpath}" \
-    ${main_class} "$@" ${tmp_dir}
-retCode=$?
-
-# We remove the trap so the return code doesn't get intercepted by it on OS X.
-cd ${root_path}
-rm -rf ${tmp_dir}
-trap - EXIT
-
-exit $retCode
+    ${main_class} "." "$@"

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,0 +1,8 @@
+load("//appengine:appengine.bzl", "appengine_war")
+
+appengine_war(
+    name = "examples",
+    data = ["//examples/webapp"],
+    data_path = "/examples/webapp",
+    jars = ["//examples/src:src_deploy.jar"],
+)

--- a/examples/src/App.java
+++ b/examples/src/App.java
@@ -1,0 +1,15 @@
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import java.io.IOException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class App extends HttpServlet {
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    System.out.println(userService.getCurrentUser());
+  }
+}

--- a/examples/src/BUILD
+++ b/examples/src/BUILD
@@ -1,0 +1,9 @@
+java_binary(
+    name = "src",
+    srcs = ["App.java"],
+    visibility = ["//examples:__pkg__"],
+    deps = [
+        "//appengine:javax.servlet.api",
+        "@com_google_appengine_java//:api",
+    ],
+)

--- a/examples/webapp/BUILD
+++ b/examples/webapp/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "webapp",
+    srcs = glob(["**"]),
+    visibility = ["//examples:__pkg__"],
+)

--- a/examples/webapp/WEB-INF/appengine-web.xml
+++ b/examples/webapp/WEB-INF/appengine-web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>example-app</application>
+  <version>1</version>
+  <threadsafe>true</threadsafe>
+  <public-root>/static</public-root>
+</appengine-web-app>

--- a/examples/webapp/WEB-INF/web.xml
+++ b/examples/webapp/WEB-INF/web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE web-app PUBLIC "-//Oracle Corporation//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" version="2.5">
+  <servlet>
+    <servlet-name>MyApp</servlet-name>
+    <servlet-class>App</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>MyApp</servlet-name>
+    <url-pattern>/*</url-pattern>
+  </servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
This reverts commit 404c74f5687a3df1ad585219dac3bd371ab5f450.

Reverts the change I made to the :api target, although I removed the hundreds of jars from the classpath. Previously the bazel rule would add appengine-sdk/lib/**/*.jar to the CLASSPATH. You can still include these jars by depending on //:jars from your whatever_deploy.jar rule.