### PR TITLE
Make the .deploy rule resolve the dependencies

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <div class="toc">
   <h2>Rules</h2>
   <ul>
-    <li><a href="#appengine_war">appengine_war</a></li>
-    <li><a href="#java_war">java_war</a></li>
+    <li><a href="#appengine">appengine</a></li>
+    <li><a href="#java_appengine">java_appengine</a></li>
   </ul>
 </div>
 
@@ -53,10 +53,12 @@ application:
             appengine-web.xml
 ```
 
+### BUILD definition
+
 Then, to build your webapp, your `hello_app/BUILD` can look like:
 
 ```python
-load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_war")
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine")
 
 java_library(
     name = "mylib",
@@ -67,7 +69,7 @@ java_library(
     ],
 )
 
-appengine_war(
+appengine(
     name = "myapp",
     jars = [":mylib"],
     data = glob(["webapp/**"]),
@@ -75,11 +77,12 @@ appengine_war(
 )
 ```
 
-For simplicity, you can use the `java_war` rule to build an app from source.
+For simplicity, you can alternatively use the `java_appengine` rule to build an app
+from source.
 Your `hello_app/BUILD` file would then look like:
 
 ```python
-load("@io_bazel_rules_appengine//appengine:appengine.bzl", "java_war")
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "java_appengine")
 
 java_war(
     name = "myapp",
@@ -93,16 +96,23 @@ java_war(
 )
 ```
 
-You can then build the application with `bazel build //hello_app:myapp` and
-run in it a development server with `bazel run //hello_app:myapp`. This will
-bind a test server on port 8080. If you wish to select another port,
+You can then build the application with `bazel build //hello_app:myapp`.
+
+### Run on a local server
+
+You can run it in a development server with `bazel run //hello_app:myapp`.
+This will bind a test server on port 8080. If you wish to select another port,
 simply append the `--port=12345` to the command-line.
 
+### Deploy on Google app engine
+
 Another target `//hello_app:myapp.deploy` allows you to deploy your
-application to App Engine. It takes an optional argument: the
-`APP_ID`. If not specified, it uses the default `APP_ID` provided in
-the application. This target needs to be authorized to App Engine. Since
-Bazel does not connect the standard input, it is easier to run it by:
+application to App Engine.
+
+It takes an optional argument: the `APP_ID`. If not specified, it uses the
+default `APP_ID` provided in the application. This target needs to be
+authorized to App Engine. Since Bazel does not connect the standard input,
+it is easier to run it by:
 ```
 bazel-bin/hello_app/myapp.deploy APP_ID
 ```
@@ -112,11 +122,11 @@ App Engine so you can just do a normal `bazel run
 //hello_app:myapp.deploy APP_ID` to deploy next versions of
 your application.
 
-<a name="appengine_war"></a>
-## appengine_war
+<a name="appengine"></a>
+## appengine
 
 ```python
-appengine_war(name, jars, data, data_path)
+appengine(name, jars, data, data_path)
 ```
 
 <table class="table table-condensed table-bordered table-params">
@@ -180,11 +190,11 @@ appengine_war(name, jars, data, data_path)
   </tbody>
 </table>
 
-<a name="java_war"></a>
-## java_war
+<a name="java_appengine"></a>
+## java_appengine
 
-```
-java_war(name, data, data_path, **kwargs)
+```pyhton
+java_appengine(name, data, data_path, **kwargs)
 ```
 
 <table class="table table-condensed table-bordered table-params">
@@ -235,7 +245,7 @@ java_war(name, data, data_path, **kwargs)
   </tbody>
 </table>
 
-# Using a local AppEngine SDK
+## Using a local AppEngine SDK
 
 You can, optionally, specify the environment variable APPENGINE_SDK_PATH to use
 an SDK that is on your filesystem (instead of downloading a new one).

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <div class="toc">
   <h2>Rules</h2>
   <ul>
-    <li><a href="#appengine">appengine</a></li>
-    <li><a href="#java_appengine">java_appengine</a></li>
+    <li><a href="#appengine_war">appengine_war</a></li>
+    <li><a href="#java_war">java_war</a></li>
   </ul>
 </div>
 
@@ -58,7 +58,7 @@ application:
 Then, to build your webapp, your `hello_app/BUILD` can look like:
 
 ```python
-load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine")
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_war")
 
 java_library(
     name = "mylib",
@@ -69,7 +69,7 @@ java_library(
     ],
 )
 
-appengine(
+appengine_war(
     name = "myapp",
     jars = [":mylib"],
     data = glob(["webapp/**"]),
@@ -77,12 +77,11 @@ appengine(
 )
 ```
 
-For simplicity, you can alternatively use the `java_appengine` rule to build an app
-from source.
+For simplicity, you can use the `java_war` rule to build an app from source.
 Your `hello_app/BUILD` file would then look like:
 
 ```python
-load("@io_bazel_rules_appengine//appengine:appengine.bzl", "java_appengine")
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "java_war")
 
 java_war(
     name = "myapp",
@@ -122,11 +121,11 @@ App Engine so you can just do a normal `bazel run
 //hello_app:myapp.deploy APP_ID` to deploy next versions of
 your application.
 
-<a name="appengine"></a>
-## appengine
+<a name="appengine_war"></a>
+## appengine_war
 
 ```python
-appengine(name, jars, data, data_path)
+appengine_war(name, jars, data, data_path)
 ```
 
 <table class="table table-condensed table-bordered table-params">
@@ -190,11 +189,11 @@ appengine(name, jars, data, data_path)
   </tbody>
 </table>
 
-<a name="java_appengine"></a>
-## java_appengine
+<a name="java_war"></a>
+## java_war
 
-```pyhton
-java_appengine(name, data, data_path, **kwargs)
+```python
+java_war(name, data, data_path, **kwargs)
 ```
 
 <table class="table table-condensed table-bordered table-params">

--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -110,7 +110,7 @@ def _short_path_dirname(path):
   return sp[0:len(sp)-len(path.basename)-1]
 
 def _war_impl(ctxt):
-  """Implentation of the rule that creates
+  """Implementation of the rule that creates
      - the war
      - the script to deploy
   """

--- a/appengine/appengine_deploy.sh.template
+++ b/appengine/appengine_deploy.sh.template
@@ -19,10 +19,8 @@ case "$0" in
 esac
 
 if [[ -z "$JAVA_RUNFILES" ]]; then
-  if [[ -e "${self%.deploy}.runfiles" ]]; then
-    JAVA_RUNFILES="${self%.deploy}.runfiles"
-  else
-    JAVA_RUNFILES=$PWD
+  if [[ -e "${self}.runfiles/%{workspace_name}" ]]; then
+    JAVA_RUNFILES="${self}.runfiles/%{workspace_name}"
   fi
 fi
 
@@ -30,10 +28,11 @@ root_path=$(pwd)
 tmp_dir=$(mktemp -d ${TMPDIR:-/tmp}/war.XXXXXXXX)
 trap "{ cd ${root_path}; rm -rf ${tmp_dir}; }" EXIT
 cd ${tmp_dir}
-${JAVA_RUNFILES}/%{workspace_name}/%{zipper} x ${JAVA_RUNFILES}/%{workspace_name}/%{war}
+
+${JAVA_RUNFILES}/%{zipper} x ${JAVA_RUNFILES}/%{war}
 cd ${root_dir}
 
-APP_ENGINE_ROOT=${JAVA_RUNFILES}/%{workspace_name}/%{appengine_sdk}
+APP_ENGINE_ROOT=${JAVA_RUNFILES}/%{appengine_sdk}
 if [ -n "${1-}" ]; then
   ${APP_ENGINE_ROOT}/bin/appcfg.sh -A "$1" update ${tmp_dir}
   retCode=$?


### PR DESCRIPTION
Issue #31 (zipper: no such file directory) is caused by an unresolved dependency.

When the user invokes `blaze run //foo/bar/gae:gae.deploy`, the target is only a `ctx.template_action`, i.e. Bazel generates the deploy script, but has no reason to actually build the war (nor resolve the zipper dependency).

The only reson why `blaze run //foo/bar/gae:gae` successfully starts a local server is because the launcher script has the same name as the `appengine_war` rule.

To work around this issue, I'm adding a bazel macro that defines a `sh_binary` which depends on the war. Essentially:

    def appengine(name, jars, data, data_path):
      appengine_war(name = name,
                jars = jars,
                data = data,
                data_path = data_path)
      native.sh_binary(name = "%s.deploy" % name,
                 srcs = ["%s_deploy.sh" % name],
                 data = [name])

Also, remove erroneous declaration of `JAVA_RUNTIMES` in the deploy template.

Fixes #31.