### PR TITLE
Revert "Make the .deploy rule resolve the dependencies"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ application:
             appengine-web.xml
 ```
 
-### BUILD definition
-
 Then, to build your webapp, your `hello_app/BUILD` can look like:
 
 ```python
@@ -95,23 +93,16 @@ java_war(
 )
 ```
 
-You can then build the application with `bazel build //hello_app:myapp`.
-
-### Run on a local server
-
-You can run it in a development server with `bazel run //hello_app:myapp`.
-This will bind a test server on port 8080. If you wish to select another port,
+You can then build the application with `bazel build //hello_app:myapp` and
+run in it a development server with `bazel run //hello_app:myapp`. This will
+bind a test server on port 8080. If you wish to select another port,
 simply append the `--port=12345` to the command-line.
 
-### Deploy on Google app engine
-
 Another target `//hello_app:myapp.deploy` allows you to deploy your
-application to App Engine.
-
-It takes an optional argument: the `APP_ID`. If not specified, it uses the
-default `APP_ID` provided in the application. This target needs to be
-authorized to App Engine. Since Bazel does not connect the standard input,
-it is easier to run it by:
+application to App Engine. It takes an optional argument: the
+`APP_ID`. If not specified, it uses the default `APP_ID` provided in
+the application. This target needs to be authorized to App Engine. Since
+Bazel does not connect the standard input, it is easier to run it by:
 ```
 bazel-bin/hello_app/myapp.deploy APP_ID
 ```
@@ -192,7 +183,7 @@ appengine_war(name, jars, data, data_path)
 <a name="java_war"></a>
 ## java_war
 
-```python
+```
 java_war(name, data, data_path, **kwargs)
 ```
 
@@ -244,7 +235,7 @@ java_war(name, data, data_path, **kwargs)
   </tbody>
 </table>
 
-## Using a local AppEngine SDK
+# Using a local AppEngine SDK
 
 You can, optionally, specify the environment variable APPENGINE_SDK_PATH to use
 an SDK that is on your filesystem (instead of downloading a new one).

--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -30,11 +30,6 @@ appengine_war(
   data_path = "/java/com/google/examples/mywebapp",
 )
 
-To test locally:
-bazel run :MyWebApp
-
-To deploy on Google app engine:
-bazel run :MyWebApp.deploy
 
 You can also make directly a single target for it with:
 
@@ -63,8 +58,8 @@ appengine_war(
   data_path = "...",
 )
 
-Finally, the appengine macro also create a .deploy target that will try to use the
-AppEngine SDK to upload your application to AppEngine. It takes an optional argument: the
+This rule will also create a .deploy target that will try to use the AppEngine
+SDK to upload your application to AppEngine. It takes an optional argument: the
 APP_ID. If not specified, it uses the default APP_ID provided in the application
 web.xml.
 """
@@ -103,10 +98,6 @@ def _short_path_dirname(path):
   return sp[0:len(sp)-len(path.basename)-1]
 
 def _war_impl(ctxt):
-  """Implementation of the rule that creates
-     - the war
-     - the script to deploy
-  """
   zipper = ctxt.file._zipper
 
   data_path = ctxt.attr.data_path
@@ -189,9 +180,10 @@ def _war_impl(ctxt):
       substitutions = substitutions,
       executable = True)
   ctxt.template_action(
-      output = ctxt.outputs.deploy_sh,
+      output = ctxt.outputs.deploy,
       template = ctxt.file._deploy_template,
-      substitutions = substitutions)
+      substitutions = substitutions,
+      executable = True)
 
   runfiles = ctxt.runfiles(files = [war, executable]
                            + list(transitive_deps)
@@ -200,7 +192,7 @@ def _war_impl(ctxt):
                            + [ctxt.file._java, ctxt.file._zipper])
   return struct(runfiles = runfiles)
 
-appengine_war_base = rule(
+appengine_war = rule(
     _war_impl,
     attrs = {
         "_java": attr.label(
@@ -235,33 +227,17 @@ appengine_war_base = rule(
     executable = True,
     outputs = {
         "war": "%{name}.war",
-        "deploy_sh": "%{name}_deploy.sh",
+        "deploy": "%{name}.deploy",
     },
 )
 
 def java_war(name, data=[], data_path=None, **kwargs):
-  """Convenience macro to call appengine_war with Java sources rather than jar.
-  """
   native.java_library(name = "lib%s" % name, **kwargs)
   appengine_war(name = name,
                 jars = ["lib%s" % name],
                 data=data,
                 data_path=data_path)
 
-def appengine_war(name, jars, data, data_path):
-  """Convenience macro that builds the war and offers an executable
-     target to deploy on Google app engine.
-  """
-  appengine_war_base(name = name,
-                jars = jars,
-                data = data,
-                data_path = data_path)
-  # Create the executable rule to deploy
-  native.sh_binary(name = "%s.deploy" % name,
-                   srcs = ["%s_deploy.sh" % name],
-                   data = [name])
-
-                    
 APPENGINE_VERSION = "1.9.48"
 
 APPENGINE_DIR = "appengine-java-sdk-" + APPENGINE_VERSION

--- a/appengine/appengine_deploy.sh.template
+++ b/appengine/appengine_deploy.sh.template
@@ -19,8 +19,10 @@ case "$0" in
 esac
 
 if [[ -z "$JAVA_RUNFILES" ]]; then
-  if [[ -e "${self}.runfiles/%{workspace_name}" ]]; then
-    JAVA_RUNFILES="${self}.runfiles/%{workspace_name}"
+  if [[ -e "${self%.deploy}.runfiles" ]]; then
+    JAVA_RUNFILES="${self%.deploy}.runfiles"
+  else
+    JAVA_RUNFILES=$PWD
   fi
 fi
 
@@ -28,11 +30,10 @@ root_path=$(pwd)
 tmp_dir=$(mktemp -d ${TMPDIR:-/tmp}/war.XXXXXXXX)
 trap "{ cd ${root_path}; rm -rf ${tmp_dir}; }" EXIT
 cd ${tmp_dir}
-
-${JAVA_RUNFILES}/%{zipper} x ${JAVA_RUNFILES}/%{war}
+${JAVA_RUNFILES}/%{workspace_name}/%{zipper} x ${JAVA_RUNFILES}/%{workspace_name}/%{war}
 cd ${root_dir}
 
-APP_ENGINE_ROOT=${JAVA_RUNFILES}/%{appengine_sdk}
+APP_ENGINE_ROOT=${JAVA_RUNFILES}/%{workspace_name}/%{appengine_sdk}
 if [ -n "${1-}" ]; then
   ${APP_ENGINE_ROOT}/bin/appcfg.sh -A "$1" update ${tmp_dir}
   retCode=$?


### PR DESCRIPTION
Reverts bazelbuild/rules_appengine#32

This breaks our CI (http://ci.bazel.io/view/Dashboard/job/rules_appengine/BAZEL_VERSION=HEAD,PLATFORM_NAME=linux-x86_64/lastFailedBuild/console) because it is now a macro which doesn't understand "testonly".  Should be a simple fix, but rolling back for now to keep the CI green.