### PR TITLE
Fix reference to singlejar

### DIFF
--- a/appengine/BUILD
+++ b/appengine/BUILD
@@ -39,7 +39,7 @@ java_toolchain(
         "-XX:+TieredCompilation",
         "-XX:TieredStopAtLevel=1",
     ],
-    singlejar = ["@bazel_tools//tools/jdk:SingleJar_deploy.jar"],
+    singlejar = ["@bazel_tools//tools/jdk:singlejar"],
     source_version = "7",
     target_version = "7",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Bazel's commit 202d5910a194ae5a0dfbc11692a17e8013017aca changes how singlejar is referenced, change to update.