### PR TITLE
Support creating war files with many files

### DIFF
--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -85,7 +85,8 @@ def _make_war(zipper, input_dir, output):
   return [
       "(root=$(pwd);" +
       ("cd %s &&" % input_dir) +
-      ("${root}/%s Cc ${root}/%s $(find .))" % (zipper.path, output.path))
+      ("find . ! -type d > $root/file_list &&") +
+      ("${root}/%s Cc ${root}/%s @${root}/file_list)" % (zipper.path, output.path))
       ]
 
 def _common_substring(str1, str2):


### PR DESCRIPTION
Currently the creation of a war file fails when it contains too many
files with the error 'Argument list too long'. This is fixed by creating
a file with the list of input files.