### PR TITLE
add bazel CI configuration

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,17 @@
+---
+platforms:
+  ubuntu1404:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  ubuntu1604:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  macos:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build status](https://badge.buildkite.com/98ffeea8dc7631a8a7d7af13cbe7570a7209a98ef18fe3cbc5.svg)](https://buildkite.com/bazel/appengine-rules-appengine-postsubmit)
+
 # App Engine Rules for Bazel
 
 <div class="toc">


### PR DESCRIPTION
Bazel is moving to a new CI system and we would like to test every commit to rules_appengine to make sure a new release doesn't break it.