### PR TITLE
Use the standard idiom for accessing the JDK

### DIFF
--- a/test/java/BUILD
+++ b/test/java/BUILD
@@ -20,10 +20,13 @@ java_binary(
 sh_test(
     name = "check_war",
     srcs = ["check_war.sh"],
+    args = ["$(JAVABASE)"],
     data = [
         ":test-war",
-        "@local_jdk//:jar",
-        "@local_jdk//:jdk-default",
+        "@bazel_tools//tools/jdk:current_java_runtime",
+    ],
+    toolchains = [
+        "@bazel_tools//tools/jdk:current_java_runtime",
     ],
 )
 

--- a/test/java/check_war.sh
+++ b/test/java/check_war.sh
@@ -7,7 +7,7 @@ if [ -d "${TEST_SRCDIR}/io_bazel_rules_appengine" ]; then
   RUNFILES="${TEST_SRCDIR}/io_bazel_rules_appengine"
 fi
 TEST_WAR="${RUNFILES}/test/java/test-war.war"
-JAR="${TEST_SRCDIR}/local_jdk/bin/jar"
+JAR="$1/bin/jar"
 
 function assert_war_contains() {
   local needle="$1"


### PR DESCRIPTION
instead of `@local_jdk//:jdk-default`, which is going away in a future
Bazel release.