### PR TITLE
Use full target names

### DIFF
--- a/appengine/java_appengine.bzl
+++ b/appengine/java_appengine.bzl
@@ -77,11 +77,18 @@ jar_filetype = FileType([".jar"])
 def _add_file(in_file, output, path = None):
   output_path = output
   input_path = in_file.path
+
   if path and in_file.short_path.startswith(path):
     output_path += in_file.short_path[len(path):]
+
+  if in_file.basename.endswith(".jar") and in_file.owner.package:
+    filename = "%s/%s" % (in_file.owner.package, in_file.basename)
+    filename = filename.replace("/", "_").replace("=", "_")
+    output_path = "%s/%s" % (output_path, filename)
+
   return [
       "mkdir -p $(dirname %s)" % output_path,
-      "test -L %s || ln -s $(pwd)/%s %s" % (output_path, input_path, output_path)
+      "test -L %s || ln -s $(pwd)/%s %s" % (output_path, input_path, output_path),
       ]
 
 def _make_war(zipper, input_dir, output):

--- a/test/java/check_war.sh
+++ b/test/java/check_war.sh
@@ -18,7 +18,7 @@ function assert_war_contains() {
   return 1
 }
 
-assert_war_contains "./WEB-INF/lib/app_deploy.jar"
+assert_war_contains "./WEB-INF/lib/test_java_app_deploy.jar"
 assert_war_contains "./WEB-INF/lib/appengine-api.jar"
 assert_war_contains "./WEB-INF/appengine-web.xml"
 assert_war_contains "./WEB-INF/web.xml"


### PR DESCRIPTION
Use package name to create a "full" target name, hence, supporting targets with the same name originating from different packages