### PR TITLE
Fixes CI caused by missing appengine_repositories()

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,10 @@
 workspace(name = "io_bazel_rules_appengine")
 
+load("//appengine:sdk.bzl", "appengine_repositories")
 load("//appengine:java_appengine.bzl", "java_appengine_repositories")
 load("//appengine:py_appengine.bzl", "py_appengine_repositories")
+
+appengine_repositories()
 
 java_appengine_repositories()
 


### PR DESCRIPTION
Adds the appengine_repositories() rule to the WORKSPACE which was added 8122a70. This rule is now  required for the python rules (and will be for the java rules once I update them).

Fixes https://github.com/bazelbuild/rules_appengine/issues/87