### PR TITLE
Python: Add option to not overwrite the appengine_config.py

### DIFF
--- a/appengine/py_appengine.bzl
+++ b/appengine/py_appengine.bzl
@@ -101,18 +101,6 @@ sys.path.extend([d for d in repo_dirs if os.path.isdir(d)])
         for f in files:
             if f.basename == "appengine_config.py":
                 appengine_config = f
-
-#                # Symlink the user-provided appengine_config file(s) to avoid name
-#                # collisions and add import(s) from the custom appengine_config being
-#                # created.
-#                new_path = f.short_path.replace(
-#                    "appengine_config",
-#                    "real_appengine_config",
-#                )
-#                symlinks[new_path] = f
-#
-#                import_path = new_path.rsplit(".", 1)[0].replace("/", ".")
-#                config_content += "\nimport {}\n".format(import_path)
             elif f.extension == "yaml":
                 # Symlink YAML config files to the top-level directory.
                 symlinks[f.basename] = f
@@ -120,14 +108,26 @@ sys.path.extend([d for d in repo_dirs if os.path.isdir(d)])
                 # Fail if any .py files were provided that were not appengine_configs.
                 fail("Invalid config file provided: " + f.short_path)
 
-    if appengine_config:
-        # If the user specified an appengine config, trust they know what they're doing and use it
+    if ctx.attr.dont_overwrite_appengine_config and appengine_config:
         ctx.actions.run_shell(
             inputs = [appengine_config],
             outputs = [config],
-            command = "cp %s %s" % (appengine_config.path, config.path)
+            command = "cp %s %s" % (appengine_config.path, config.path),
         )
     else:
+        if appengine_config:
+            # Symlink the user-provided appengine_config file(s) to avoid name
+            # collisions and add import(s) from the custom appengine_config being
+            # created.
+            new_path = f.short_path.replace(
+                "appengine_config",
+                "real_appengine_config",
+            )
+            symlinks[new_path] = f
+
+            import_path = new_path.rsplit(".", 1)[0].replace("/", ".")
+            config_content += "\nimport {}\n".format(import_path)
+
         ctx.actions.write(
             output = config,
             content = config_content,
@@ -174,6 +174,11 @@ py_appengine_binary_base = rule(
             ".yaml",
             ".py",
         ])),
+        "dont_overwrite_appengine_config": attr.bool(
+            doc = """"If false, patch the user's appengine_config into the base one. If true, use
+                      the user specified config directly.""",
+            default = False
+        ),
         "_deploy_template": attr.label(
             default = Label("//appengine/py:deploy_template"),
             single_file = True,
@@ -189,7 +194,7 @@ py_appengine_binary_base = rule(
     },
 )
 
-def py_appengine_binary(name, srcs, configs, deps = [], data = []):
+def py_appengine_binary(name, srcs, configs, deps = [], data = [], **kwargs):
     """Convenience macro that builds the app and offers an executable
 
          target to deploy on Google app engine.
@@ -209,6 +214,7 @@ def py_appengine_binary(name, srcs, configs, deps = [], data = []):
         name = name,
         binary = ":_py_appengine_" + name,
         configs = configs,
+        **kwargs
     )
     native.sh_binary(
         name = "%s.deploy" % name,

--- a/appengine/py_appengine.bzl
+++ b/appengine/py_appengine.bzl
@@ -108,7 +108,7 @@ sys.path.extend([d for d in repo_dirs if os.path.isdir(d)])
                 # Fail if any .py files were provided that were not appengine_configs.
                 fail("Invalid config file provided: " + f.short_path)
 
-    if ctx.attr.dont_overwrite_appengine_config and appengine_config:
+    if ctx.attr.overwrite_appengine_config and appengine_config:
         ctx.actions.run_shell(
             inputs = [appengine_config],
             outputs = [config],
@@ -174,10 +174,10 @@ py_appengine_binary_base = rule(
             ".yaml",
             ".py",
         ])),
-        "dont_overwrite_appengine_config": attr.bool(
-            doc = """"If false, patch the user's appengine_config into the base one. If true, use
+        "overwrite_appengine_config": attr.bool(
+            doc = """"If true, patch the user's appengine_config into the base one. If false, use
                       the user specified config directly.""",
-            default = False
+            default = True,
         ),
         "_deploy_template": attr.label(
             default = Label("//appengine/py:deploy_template"),
@@ -194,7 +194,7 @@ py_appengine_binary_base = rule(
     },
 )
 
-def py_appengine_binary(name, srcs, configs, deps = [], data = [], **kwargs):
+def py_appengine_binary(name, srcs, configs, deps = [], data = [], overwrite_appengine_config = True):
     """Convenience macro that builds the app and offers an executable
 
          target to deploy on Google app engine.
@@ -214,7 +214,7 @@ def py_appengine_binary(name, srcs, configs, deps = [], data = [], **kwargs):
         name = name,
         binary = ":_py_appengine_" + name,
         configs = configs,
-        **kwargs
+        overwrite_appengine_config = overwrite_appengine_config,
     )
     native.sh_binary(
         name = "%s.deploy" % name,


### PR DESCRIPTION
Currently, when the user specifies an `appengine_config.py` file, the rule patches it into a base config. This PR adds a new option, `dont_overwrite_appengine_config`, that disables the patching behavior and instead uses the user's config directly. When `dont_overwrite_appengine_config` is False, the old behavior is unchanged.