### PR TITLE
propagate yaml configs to gcloud during deployment

### DIFF
--- a/appengine/py/appengine_deploy.sh.template
+++ b/appengine/py/appengine_deploy.sh.template
@@ -34,6 +34,6 @@ trap "{ cd "$ROOT"; rm -rf "$tmp_dir"; }" EXIT
 cd "${tmp_dir}/%{workspace_name}"
 rm -Rf "external/com_google_appengine_py"
 
-$ROOT/%{gcloud_path} app deploy "${@:1}"
+$ROOT/%{gcloud_path} app deploy "${@:1}" %{configs}
 
 exit

--- a/appengine/py_appengine.bzl
+++ b/appengine/py_appengine.bzl
@@ -95,6 +95,7 @@ sys.path.extend([d for d in repo_dirs if os.path.isdir(d)])
     }
 
     appengine_config = None
+    configs = ""
 
     for c in ctx.attr.configs:
         files = c.files.to_list()
@@ -104,6 +105,7 @@ sys.path.extend([d for d in repo_dirs if os.path.isdir(d)])
             elif f.extension == "yaml":
                 # Symlink YAML config files to the top-level directory.
                 symlinks[f.basename] = f
+                configs += " \"" + f.basename + "\""
             else:
                 # Fail if any .py files were provided that were not appengine_configs.
                 fail("Invalid config file provided: " + f.short_path)
@@ -143,6 +145,7 @@ sys.path.extend([d for d in repo_dirs if os.path.isdir(d)])
         "%{devappserver}": ctx.attr.devappserver.files_to_run.executable.short_path,
         "%{gcloud_path}": ctx.attr.gcloud.files_to_run.executable.short_path,
         "%{workspace_name}": ctx.workspace_name,
+        "%{configs}": configs,
     }
 
     ctx.actions.expand_template(


### PR DESCRIPTION
'gcloud app deploy' does not deploy cron.yaml/index.yaml/dispatch.yaml by default.
It does make sense to deploy all yaml configs listed for build target by default.