### PR TITLE
remove references to jar_filetype

### DIFF
--- a/appengine/appengine.bzl
+++ b/appengine/appengine.bzl
@@ -19,7 +19,6 @@ load(
     ":java_appengine.bzl",
     _appengine_war = "appengine_war",
     _appengine_war_base = "appengine_war_base",
-    _jar_filetype = "jar_filetype",
     _java_appengine_repositories = "java_appengine_repositories",
     _java_war = "java_war",
 )
@@ -27,8 +26,6 @@ load(
 appengine_war = _appengine_war
 
 appengine_war_base = _appengine_war_base
-
-jar_filetype = _jar_filetype
 
 java_appengine_repositories = _java_appengine_repositories
 


### PR DESCRIPTION
master is currently broken because of two remaining references to `jar_filetype `.

`jar_filetype ` was previously removed here: https://github.com/bazelbuild/rules_appengine/commit/a69412e221aed66db2d69d4ff471229365859058