### PR TITLE
Small fix to build with --incompatible_disallow_legacy_py_provider

### DIFF
--- a/appengine/py_appengine.bzl
+++ b/appengine/py_appengine.bzl
@@ -162,7 +162,7 @@ sys.path.extend([d for d in repo_dirs if os.path.isdir(d)])
         is_executable = True,
     )
 
-    return struct(runfiles = runfiles, py = ctx.attr.binary.py)
+    return [DefaultInfo(runfiles = runfiles), ctx.attr.binary[PyInfo]]
 
 py_appengine_binary_base = rule(
     _py_appengine_binary_base_impl,


### PR DESCRIPTION
This incompatible change flag, and the PyInfo provider it requires, were introduced in Bazel 0.23. The incompatible change may be enabled as soon as Bazel 0.25.