### PR TITLE
Remove extclasspath and put javac into tools attribute.

### DIFF
--- a/appengine/BUILD
+++ b/appengine/BUILD
@@ -15,7 +15,6 @@ filegroup(
 java_toolchain(
     name = "jdk8",
     bootclasspath = ["@bazel_tools//tools/jdk:bootclasspath"],
-    extclasspath = ["@bazel_tools//tools/jdk:extdir"],
     genclass = ["@bazel_tools//tools/jdk:GenClass_deploy.jar"],
     header_compiler = ["@bazel_tools//tools/jdk:turbine_deploy.jar"],
     ijar = ["@bazel_tools//tools/jdk:ijar"],

--- a/appengine/BUILD
+++ b/appengine/BUILD
@@ -19,7 +19,7 @@ java_toolchain(
     header_compiler = ["@bazel_tools//tools/jdk:turbine_deploy.jar"],
     ijar = ["@bazel_tools//tools/jdk:ijar"],
     javabuilder = ["@bazel_tools//tools/jdk:JavaBuilder_deploy.jar"],
-    javac = ["@bazel_tools//third_party/java/jdk/langtools:javac_jar"],
+    tools = ["@bazel_tools//third_party/java/jdk/langtools:javac_jar"],
     javac_supports_workers = 1,
     jvm_opts = [
         "-XX:+TieredCompilation",


### PR DESCRIPTION
The implementation of java_toolchain already does nothing with the extclasspath value. The attribute has been removed.

javac is handled the same way if added to tools attribute.