### PR TITLE
Setup JDK8 toolchain depending on the Bazel version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ java.lang.IllegalArgumentException: Class file is Java 9 but max supported is Ja
 To build with Java 8, use the toolchain bundled with these App Engine rules:
 
 ```
-$ bazel build --java_toolchain=@io_bazel_rules_appengine//appengine:jdk8 //my-project
+$ bazel build --extra_toolchains=@io_bazel_rules_appengine//appengine/jdk:jdk8_definition //my-project
 ```
 
 To avoid having to specify this toolchain during every build, you can add this
@@ -211,7 +211,7 @@ to your project's `.bazelrc`.  Create a `.bazelrc` file in the root directory of
 your project and add the line:
 
 ```
-build --java_toolchain=@io_bazel_rules_appengine//appengine:jdk8
+build --extra_toolchains=@io_bazel_rules_appengine//appengine/jdk:jdk8_definition
 ```
 
 <a name="appengine_war"></a>

--- a/appengine/BUILD
+++ b/appengine/BUILD
@@ -12,21 +12,8 @@ filegroup(
     visibility = ["//tools:__pkg__"],
 )
 
-java_toolchain(
+alias(
     name = "jdk8",
-    bootclasspath = ["@bazel_tools//tools/jdk:bootclasspath"],
-    genclass = ["@bazel_tools//tools/jdk:GenClass_deploy.jar"],
-    header_compiler = ["@bazel_tools//tools/jdk:turbine_deploy.jar"],
-    ijar = ["@bazel_tools//tools/jdk:ijar"],
-    javabuilder = ["@bazel_tools//tools/jdk:JavaBuilder_deploy.jar"],
-    tools = ["@bazel_tools//third_party/java/jdk/langtools:javac_jar"],
-    javac_supports_workers = 1,
-    jvm_opts = [
-        "-XX:+TieredCompilation",
-        "-XX:TieredStopAtLevel=1",
-    ],
-    singlejar = ["@bazel_tools//tools/jdk:singlejar"],
-    source_version = "8",
-    target_version = "8",
+    actual = "@rules_appengine_toolchain//:jdk8",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
I replaced direct use of "java_toolchain" rule with "default_java_toolchain" macro, which already has some good defaults and it exists in Bazel for quite some time. Macro is easier to maintain, because the defaults can be changed within Bazel.

Newer Bazel (>4.0.0) is changing how Java toolchains are resolved. I updated the README.md accordingly. In newer version of Bazel it is easier to use the macro, because it also adds necessary toolchain definitions.

Newer Bazel also has presets for JVM8 configuration which I used in "default_java_toolchain". The preset in newer version is needed, because it will ensure code is compiled on JDK8 for JVM8. Without it the code is compiled on JDK11 for JVM8.

The whole commit is a bit complicated, but I don't know an easier way how to have rules_appengine backwards and forward compatible.