### PR TITLE
Import JDK8 from remote repository and add instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_java",
     sha256 = "7c4bbe11e41c61212a5cf16d9aafaddade3f5b1b6c8bf94270d78215fafd4007",
+    strip_prefix = "rules_java-c13e3ead84afb95f81fbddfade2749d8ba7cb77f",
     url = "https://github.com/bazelbuild/rules_java/archive/c13e3ead84afb95f81fbddfade2749d8ba7cb77f.tar.gz",  # 2021-01-25
 )
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,24 @@ your project and add the line:
 build --extra_toolchains=@io_bazel_rules_appengine//appengine/jdk:jdk8_definition
 ```
 
+In case you don't want to install JDK 8 on the machine running Bazel, you can
+import remote JDK8 repositories by adding the following lines to your WORKSPACE
+file:
+
+```python
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_java",
+    sha256 = "7c4bbe11e41c61212a5cf16d9aafaddade3f5b1b6c8bf94270d78215fafd4007",
+    url = "https://github.com/bazelbuild/rules_java/archive/c13e3ead84afb95f81fbddfade2749d8ba7cb77f.tar.gz",  # 2021-01-25
+)
+
+load("@rules_java//java:repositories.bzl", "remote_jdk8_repos")
+
+remote_jdk8_repos()
+```
+
 <a name="appengine_war"></a>
 ## appengine_war
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,7 @@ bazel_skylib_workspace()
 http_archive(
     name = "rules_java",
     sha256 = "7c4bbe11e41c61212a5cf16d9aafaddade3f5b1b6c8bf94270d78215fafd4007",
+    strip_prefix = "rules_java-c13e3ead84afb95f81fbddfade2749d8ba7cb77f",
     url = "https://github.com/bazelbuild/rules_java/archive/c13e3ead84afb95f81fbddfade2749d8ba7cb77f.tar.gz",  # 2021-01-25
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,7 @@
 workspace(name = "io_bazel_rules_appengine")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "bazel_skylib",
     urls = [
@@ -11,6 +12,16 @@ http_archive(
 )
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
+
+http_archive(
+    name = "rules_java",
+    sha256 = "7c4bbe11e41c61212a5cf16d9aafaddade3f5b1b6c8bf94270d78215fafd4007",
+    url = "https://github.com/bazelbuild/rules_java/archive/c13e3ead84afb95f81fbddfade2749d8ba7cb77f.tar.gz",  # 2021-01-25
+)
+
+load("@rules_java//java:repositories.bzl", "remote_jdk8_repos")
+
+remote_jdk8_repos()
 
 load("//appengine:sdk.bzl", "appengine_repositories")
 load("//appengine:java_appengine.bzl", "java_appengine_repositories")


### PR DESCRIPTION
This enables rules_appengine to work on machines, that don't have
JDK 8 installed.

Fixes https://github.com/bazelbuild/rules_appengine/issues/119