### PR TITLE
Use bazel-skylib for a proper version check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Bazel. The easiest way to do so is by adding the following to your
 Note: The `${LANG}_appengine_repository()` lines are only needed for the languages you plan to use.
 
 ```python
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
 git_repository(
     name = "io_bazel_rules_appengine",
     remote = "https://github.com/bazelbuild/rules_appengine.git",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,17 @@
 workspace(name = "io_bazel_rules_appengine")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
 load("//appengine:sdk.bzl", "appengine_repositories")
 load("//appengine:java_appengine.bzl", "java_appengine_repositories")
 load("//appengine:py_appengine.bzl", "py_appengine_repositories")

--- a/appengine/java_appengine.bzl
+++ b/appengine/java_appengine.bzl
@@ -71,6 +71,7 @@ APP_ID. If not specified, it uses the default APP_ID provided in the application
 web.xml.
 """
 
+load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 load(":variables.bzl", "JAVA_SDK_SHA256", "JAVA_SDK_VERSION")
 load(":sdk.bzl", "find_locally_or_download")
@@ -317,12 +318,7 @@ def java_appengine_repositories(
         licenses = ["reciprocal"],  # CDDL License
     )
 
-    if len(native.bazel_version) > 0:
-        bazel_version = tuple([int(n) for n in native.bazel_version.split(".")])
-    else:
-        bazel_version = ()  # Bazel@HEAD
-
-    if bazel_version > (4, 0, 0) or bazel_version == ():
+    if not versions.get() or not versions.is_at_most("4.0.0", versions.get()): # development or version > 4.0.0
         build_file_content = """
 load(
     "@bazel_tools//tools/jdk:default_java_toolchain.bzl",


### PR DESCRIPTION
I imported bazel-skylib and used version check from there.

Fixes https://github.com/bazelbuild/rules_appengine/issues/122
