### PR TITLE
Prepare repo for archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+🚨 rules_appengine is no longer maintained.
+
+
 [![Build status](https://badge.buildkite.com/98ffeea8dc7631a8a7d7af13cbe7570a7209a98ef18fe3cbc5.svg)](https://buildkite.com/bazel/appengine-rules-appengine-postsubmit)
 
 


### PR DESCRIPTION
It has been unmaintained for over a year. See https://oss-compass.org/analyze/s2cg17ca for data to support this.

The last maintainer says it is appropriate to archive: https://github.com/bazelbuild/rules_appengine/issues/128#issuecomment-1745669844